### PR TITLE
Fixed property name for current file

### DIFF
--- a/src/com/rr/ota/RROTA.java
+++ b/src/com/rr/ota/RROTA.java
@@ -153,7 +153,7 @@ public class RROTA extends PreferenceFragment implements OnSharedPreferenceChang
                     mStrCurVer = line[1];
                 } else if (line[0].equalsIgnoreCase("ro.product.model")) {
                     mStrDevice = line[1];
-                } else if (line[0].equalsIgnoreCase("ro.rr_modversion")) {
+                } else if (line[0].equalsIgnoreCase("ro.cm.display.version")) {
                     mStrCurFile = line[1];
                 }
             }

--- a/src/com/rr/ota/RROTA.java
+++ b/src/com/rr/ota/RROTA.java
@@ -153,7 +153,7 @@ public class RROTA extends PreferenceFragment implements OnSharedPreferenceChang
                     mStrCurVer = line[1];
                 } else if (line[0].equalsIgnoreCase("ro.product.model")) {
                     mStrDevice = line[1];
-                } else if (line[0].equalsIgnoreCase("ro.modversion")) {
+                } else if (line[0].equalsIgnoreCase("ro.rr_modversion")) {
                     mStrCurFile = line[1];
                 }
             }


### PR DESCRIPTION
Currently, in About device -> Updates, you see "File: null" under "Current Version" because it's looking for the wrong property name in build.prop. This commit fixes it.
